### PR TITLE
Simplify build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git clone https://github.com/liberated-cortex/CCOSS.git
 cd CCOSS_dependencies
 ./prepare.sh
 cd ../CCOSS
-make all PREPARED_DIR=../CCOSS_dependencies/prepared/ -j4
+make PREPARED_DIR=../CCOSS_dependencies/prepared/ -j4
 ```
 
 The executable `cortex` must be run from the main directory of your game content, copying the executable to that directory also works.


### PR DESCRIPTION
It's not necessary to say `make all`, because make will run the first target
by default. The purpose of specifying the `all` target is to explicitly
provide a default build at the beginning of the Makefile so that the user
doesn't need to know which target to use.